### PR TITLE
New slider event

### DIFF
--- a/shop/themes/child_classic/modules/ps_imageslider/views/templates/hook/slider.tpl
+++ b/shop/themes/child_classic/modules/ps_imageslider/views/templates/hook/slider.tpl
@@ -36,5 +36,18 @@
   </div>
 </div>
 
+<script>
+
+  document.addEventListener('DOMContentLoaded', function() {
+    document.getElementById('slider-container').addEventListener('click', function() {
+      gtag('event', 'kliknięcie_slider_div', {
+        'event_category': 'Obszar Slidera',
+        'event_label': 'Kliknięcie na slider',
+        'value': 1
+      });
+    });
+  });
+</script>
+
 {/if}
 


### PR DESCRIPTION

This pull request includes an enhancement to the `ps_imageslider` module in the `shop/themes/child_classic` theme. The change adds a script to track clicks on the slider div and send the event to Google Analytics.

Enhancements to event tracking:

* [`shop/themes/child_classic/modules/ps_imageslider/views/templates/hook/slider.tpl`](diffhunk://#diff-9ced09c0792abae33a8d1ee94692618bac08f50743d67776fa47986f980f7d3fR39-R51): Added a script to listen for clicks on the slider div and send a Google Analytics event with the category 'Obszar Slidera', label 'Kliknięcie na slider', and value 1.