### PR TITLE
MissSpellings in theme.yml

### DIFF
--- a/shop/themes/child_classic/config/theme.yml
+++ b/shop/themes/child_classic/config/theme.yml
@@ -7,7 +7,7 @@ assets:
   js:
       all:
         - id: analytics
-          path: assets/js/ga_analitycs.js
+          path: assets/js/ga.js
           priority: 10
           position: bottom
         - id: ga-function


### PR DESCRIPTION
In the theme.yml file, path to GA script was misspelled. Now it is corrected.