### PR TITLE
bug in path to Dockerfile in workflow .yml file

### DIFF
--- a/.github/workflows/docker-image-build-push.yml
+++ b/.github/workflows/docker-image-build-push.yml
@@ -27,5 +27,5 @@ jobs:
       with:
         push: true
         context: .
-        file: ./init/Dockerfile
+        file: ./Dockerfile
         tags: tarnowsky/ebiz-quartz:latest


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/docker-image-build-push.yml` file. The change updates the Dockerfile path used in the build process.

* [`.github/workflows/docker-image-build-push.yml`](diffhunk://#diff-68a9f37d1c368be49225f6e4174fc9b31877c61fe3e546b3a8d675db8b874616L30-R30): Changed the `file` parameter from `./init/Dockerfile` to `./Dockerfile` in the `jobs` section.